### PR TITLE
Add: ER図作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ README〜ER図作成：12/31〆切
 [画面遷移図](https://www.figma.com/file/tvDbdZaatlwxrx1UqF9Swe/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1&t=wqBr0aBA8R8MmxPt-1)
 
 ### ■ER図
-<img width="866" alt="スクリーンショット 2023-01-04 21 29 28" src="https://user-images.githubusercontent.com/86270681/210556186-bd105113-c9df-4256-b7e3-9a658b8f472c.png">
+<img width="742" alt="スクリーンショット 2023-01-05 20 46 28" src="https://user-images.githubusercontent.com/86270681/210773562-8695332a-18fd-493b-a4c2-7e57711a20f2.png">

--- a/README.md
+++ b/README.md
@@ -63,3 +63,6 @@ README〜ER図作成：12/31〆切
 
 ### ■画面遷移図
 [画面遷移図](https://www.figma.com/file/tvDbdZaatlwxrx1UqF9Swe/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1&t=wqBr0aBA8R8MmxPt-1)
+
+### ■ER図
+<img width="850" alt="スクリーンショット 2023-01-04 20 52 18" src="https://user-images.githubusercontent.com/86270681/210551062-fa6cb4fb-2dc4-4ebb-a0f7-33cdcbb4915b.png">

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ README〜ER図作成：12/31〆切
 [画面遷移図](https://www.figma.com/file/tvDbdZaatlwxrx1UqF9Swe/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1&t=wqBr0aBA8R8MmxPt-1)
 
 ### ■ER図
-<img width="742" alt="スクリーンショット 2023-01-05 20 46 28" src="https://user-images.githubusercontent.com/86270681/210773562-8695332a-18fd-493b-a4c2-7e57711a20f2.png">
+<img width="855" alt="スクリーンショット 2023-01-05 21 58 04" src="https://user-images.githubusercontent.com/86270681/210786346-f978fa52-1976-4812-a49f-3a885236c3b7.png">

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ README〜ER図作成：12/31〆切
 [画面遷移図](https://www.figma.com/file/tvDbdZaatlwxrx1UqF9Swe/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0%3A1&t=wqBr0aBA8R8MmxPt-1)
 
 ### ■ER図
-<img width="850" alt="スクリーンショット 2023-01-04 20 52 18" src="https://user-images.githubusercontent.com/86270681/210551062-fa6cb4fb-2dc4-4ebb-a0f7-33cdcbb4915b.png">
+<img width="866" alt="スクリーンショット 2023-01-04 21 29 28" src="https://user-images.githubusercontent.com/86270681/210556186-bd105113-c9df-4256-b7e3-9a658b8f472c.png">


### PR DESCRIPTION
# ER図作成
ER図を作成しました。レビューお願いします！


## ER図
<img width="866" alt="スクリーンショット 2023-01-04 21 29 28" src="https://user-images.githubusercontent.com/86270681/210555643-bcff1e58-d6d7-4a5b-9fad-b43c9b0c478a.png">

## 2022/01/05修正版ER図
<img width="855" alt="スクリーンショット 2023-01-05 21 58 04" src="https://user-images.githubusercontent.com/86270681/210786346-f978fa52-1976-4812-a49f-3a885236c3b7.png">


## 概要
### Usersテーブル
ユーザー情報を保持するテーブル
devise・omniauthを使用予定

- phone_number 電話番号
- role 権限(管理者or一般ユーザー)
- login_medium ログイン媒体(Facebookログインか電話番号ログインか識別するフラグ)
- remember_created_at ログイン日時を保持(Remember me機能で使用。remember_created_atから一定期間時間が経つとログインを促される)


### RequestHistoriesテーブル
飲み会依頼の送信履歴を保持するテーブル

- phone_number 飲み会依頼送信先電話番号
- facebook_id 飲み会依頼送信先FacebookアカウントのID


### Requestsテーブル
飲み会依頼の内容を保持するテーブル

- shop_url お店のサイトURL
- dismissal_time 希望解散時間
- number_of_people 希望人数
- atmosphere 希望する飲み会の雰囲気(静かな飲み会を0、騒がしい飲み会を100として希望する飲み会の雰囲気を数値で設定する。)
- message フリー記述


### Roomsテーブル
チャットルームテーブル

- name チャットルーム名


### UserRoomsテーブル
UsersテーブルとRoomsテーブルをつなぐ中間テーブル


### ChatMessagesテーブル
チャット内のメッセージを保持するテーブル

- message 送信したメッセージ




