### PR TITLE
開発環境のoriginをcors.rbに追加

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
  Rails.application.config.middleware.insert_before 0, Rack::Cors do
    allow do
-     origins 'https://www.nomimatch.com'
+     origins 'http://localhost:3001','https://www.nomimatch.com'
 
      resource '*',
        headers: :any,


### PR DESCRIPTION
## 概要
cors.rbに開発環境のoriginを追加した。

## なぜこの機能を追加するのか
開発環境でフロントとの動作確認連携をするため。

## やったこと
- cors.rbに開発環境のoriginを追加