### PR TITLE
Fix: 開発環境用にpuma.rbを編集

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,8 +15,11 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-# port ENV.fetch("PORT") { 3000 }
-bind "unix://#{Rails.root}/tmp/sockets/puma.sock"
+# development環境の時は以下を使用
+port ENV.fetch("PORT") { 3000 }
+
+# production環境の時は以下を使用
+# bind "unix://#{Rails.root}/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## 概要
puma.rbの内容を開発環境用に修正

## なぜこの機能を追加するのか
開発環境でフロント側との疎通状況を確認したいから

## やったこと
- puma.rbを編集した。